### PR TITLE
Add logging and error middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 main
+logs/

--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,9 @@
 from aiogram import Bot, Dispatcher
 from config import settings
 
+from utils.logger import LoggingMiddleware, ErrorMiddleware
+
 bot = Bot(token=settings.bot_token)
 dp = Dispatcher()
+dp.update.middleware(LoggingMiddleware())
+dp.update.middleware(ErrorMiddleware())

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,54 @@
+import logging
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject
+
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+ERROR_LOG_FILE = LOG_DIR / "errors.log"
+
+logger = logging.getLogger("bot")
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    error_file_handler = logging.FileHandler(ERROR_LOG_FILE)
+    error_file_handler.setLevel(logging.ERROR)
+    error_file_handler.setFormatter(formatter)
+    logger.addHandler(error_file_handler)
+
+
+class LoggingMiddleware(BaseMiddleware):
+    """Log every incoming update."""
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict,
+    ) -> Any:
+        logger.info("Incoming update: %s", event)
+        return await handler(event, data)
+
+
+class ErrorMiddleware(BaseMiddleware):
+    """Catch exceptions and log tracebacks."""
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict,
+    ) -> Any:
+        try:
+            return await handler(event, data)
+        except Exception:  # pragma: no cover - runtime safeguard
+            logger.exception("Exception while handling update")
+            raise


### PR DESCRIPTION
## Summary
- add update logging and error logging middleware
- register both middlewares in dispatcher
- ignore logs directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b9cf5aca883298aa5b66c9c84dc4f