### PR TITLE
Implement profile command with user data

### DIFF
--- a/handlers/user/level.py
+++ b/handlers/user/level.py
@@ -1,22 +1,13 @@
-from dataclasses import dataclass
-
 from aiogram import Router, F
 from aiogram.types import Message
 
-# Placeholder service for getting user level and points
-@dataclass
-class LevelInfo:
-    level: int
-    points: int
-
-async def get_level_info(user_id: int) -> LevelInfo:
-    # In a real implementation this would fetch data from a database
-    return LevelInfo(level=1, points=0)
+from services.point_service import point_service
 
 router = Router()
 
 
 @router.message(F.text == "/level")
 async def level_handler(message: Message) -> None:
-    info = await get_level_info(message.from_user.id)
-    await message.answer(f"You are level {info.level} with {info.points} points")
+    level = point_service.get_level(str(message.from_user.id))
+    points = point_service.get_points(str(message.from_user.id))
+    await message.answer(f"You are level {level} with {points} points")

--- a/handlers/user/profile.py
+++ b/handlers/user/profile.py
@@ -1,38 +1,30 @@
-from dataclasses import dataclass
-from datetime import date
 from aiogram import Router, F
 from aiogram.types import Message
 
-# Placeholder user model
-@dataclass
-class User:
-    id: int
-    full_name: str
-    level: int
-    points: int
-    join_date: date
-
-# Placeholder database fetch function
-async def get_user_from_db(user_id: int) -> User:
-    # In a real application this would query the database
-    # Here we return a dummy user for demonstration purposes
-    return User(
-        id=user_id,
-        full_name="John Doe",
-        level=1,
-        points=0,
-        join_date=date.today()
-    )
+from services.user_service import get_user
+from services.point_service import point_service
 
 router = Router()
 
+
 @router.message(F.text == "/profile")
-async def profile_handler(message: Message):
-    user = await get_user_from_db(message.from_user.id)
+async def profile_handler(message: Message) -> None:
+    user = await get_user(message.from_user.id)
+    if user is None:
+        await message.answer("You are not registered. Use /start first.")
+        return
+
+    points = point_service.get_points(str(user.id))
+    level = point_service.get_level(str(user.id))
+    rewards = point_service.get_rewards(str(user.id))
+    budget = point_service.get_budget(str(user.id))
+
     response = (
-        f"Welcome {user.full_name}!\n"
-        f"Level: {user.level}\n"
-        f"Points: {user.points}\n"
-        f"Joined: {user.join_date}"
+        f"\u2728 Perfil de {user.full_name} \u2728\n"
+        f"Nivel: {level}\n"
+        f"Puntos: {points}\n"
+        f"Recompensas: {rewards}\n"
+        f"Budget: {budget}\n"
+        f"Unido: {user.join_date.date()}"
     )
     await message.answer(response)

--- a/handlers/user/start.py
+++ b/handlers/user/start.py
@@ -5,6 +5,7 @@ from aiogram.filters import CommandStart
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from services.user_service import add_user
+from services.point_service import point_service
 
 router = Router()
 
@@ -19,6 +20,8 @@ async def start(message: types.Message):
         full_name=user.full_name,
         join_date=message.date or datetime.utcnow(),
     )
+    # add registration points
+    point_service.register_user(str(user.id))
 
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[

--- a/main.py
+++ b/main.py
@@ -3,6 +3,13 @@ import asyncio
 from bot import bot, dp
 from aiogram import types
 from aiogram.filters import Command
+from handlers.user.start import router as start_router
+from handlers.user.profile import router as profile_router
+from handlers.user.level import router as level_router
+
+dp.include_router(start_router)
+dp.include_router(profile_router)
+dp.include_router(level_router)
 
 
 @dp.message(Command("help"))

--- a/services/point_service.py
+++ b/services/point_service.py
@@ -30,3 +30,15 @@ class PointService:
         """Return the user's level based on their points."""
         points = self.get_points(user_id)
         return math.floor(points / 100)
+
+    def get_rewards(self, user_id: str) -> int:
+        """Return number of rewards earned based on points."""
+        return self.get_points(user_id) // 50
+
+    def get_budget(self, user_id: str) -> int:
+        """Simple budget calculation derived from points."""
+        return self.get_points(user_id) // 10
+
+
+# Shared instance used across handlers
+point_service = PointService()

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,5 +1,16 @@
 import sqlite3
+from dataclasses import dataclass
 from datetime import datetime
+
+
+@dataclass
+class User:
+    """Simple user representation."""
+
+    id: int
+    username: str
+    full_name: str
+    join_date: datetime
 
 DB_PATH = 'bot.db'
 
@@ -25,5 +36,26 @@ async def add_user(user_id: int, username: str, full_name: str, join_date: datet
                 "INSERT OR REPLACE INTO users (id, username, full_name, join_date) VALUES (?, ?, ?, ?)",
                 (user_id, username, full_name, join_date.isoformat()),
             )
+    finally:
+        conn.close()
+
+
+async def get_user(user_id: int) -> User | None:
+    """Retrieve a user from the database."""
+    conn = _get_connection()
+    try:
+        cur = conn.execute(
+            "SELECT id, username, full_name, join_date FROM users WHERE id = ?",
+            (user_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return User(
+            id=row[0],
+            username=row[1],
+            full_name=row[2],
+            join_date=datetime.fromisoformat(row[3]),
+        )
     finally:
         conn.close()


### PR DESCRIPTION
## Summary
- register user points at /start
- show detailed profile using new functions
- expose points via /level
- add helpers for fetching user info and calculating rewards/budget

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684baeee3d3c8329893268660f70a667