### PR TITLE
Add badge system and /badges command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-juegofinal is a small Telegram bot built with [aiogram](https://docs.aiogram.dev/) 3.0. It shows how to implement basic command handlers, persist user data in SQLite and log updates. The bot lets users register with `/start` and check their stats with `/profile` and `/level`.
+juegofinal is a small Telegram bot built with [aiogram](https://docs.aiogram.dev/) 3.0. It shows how to implement basic command handlers, persist user data in SQLite and log updates. The bot lets users register with `/start` and check their stats with `/profile`, `/level` and `/badges`.
 
 ## Setup instructions
 
@@ -39,6 +39,7 @@ python main.py
 - `/start` registers the user in SQLite and displays an inline menu.
 - `/profile` shows a user's level, points and join date.
 - `/level` reports the current level and points.
+- `/badges` lists earned badges.
 - `/help` explains available commands.
 - Basic echo handler for any other message.
 - `PointService` for registration and daily bonus points.

--- a/handlers/user/badges.py
+++ b/handlers/user/badges.py
@@ -1,0 +1,16 @@
+from aiogram import Router, F
+from aiogram.types import Message
+
+from services.point_service import point_service
+
+router = Router()
+
+
+@router.message(F.text == "/badges")
+async def badges_handler(message: Message) -> None:
+    badges = point_service.get_badges(str(message.from_user.id))
+    if badges:
+        lines = "\n".join(f"\U0001F396 {b}" for b in badges)
+        await message.answer(f"Your badges:\n{lines}")
+    else:
+        await message.answer("You have no badges yet. Keep earning points!")

--- a/main.py
+++ b/main.py
@@ -6,10 +6,12 @@ from aiogram.filters import Command
 from handlers.user.start import router as start_router
 from handlers.user.profile import router as profile_router
 from handlers.user.level import router as level_router
+from handlers.user.badges import router as badges_router
 
 dp.include_router(start_router)
 dp.include_router(profile_router)
 dp.include_router(level_router)
+dp.include_router(badges_router)
 
 
 @dp.message(Command("help"))
@@ -20,6 +22,7 @@ async def help_handler(message: types.Message) -> None:
         "/start - Register and open menu\n"
         "/profile - Show your profile\n"
         "/level - Get your level and points\n"
+        "/badges - List earned badges\n"
         "/help - Show this message"
     )
     await message.answer(instructions)

--- a/services/point_service.py
+++ b/services/point_service.py
@@ -8,6 +8,13 @@ class PointService:
     REGISTRATION_BONUS = 10
     DAILY_BONUS = 1
 
+    # Thresholds for awarding badges based on total points
+    BADGE_THRESHOLDS = [
+        (50, "Bronze"),
+        (200, "Silver"),
+        (500, "Gold"),
+    ]
+
     def __init__(self) -> None:
         # Map user identifiers to their point totals
         self._points: Dict[str, int] = {}
@@ -38,6 +45,12 @@ class PointService:
     def get_budget(self, user_id: str) -> int:
         """Simple budget calculation derived from points."""
         return self.get_points(user_id) // 10
+
+    def get_badges(self, user_id: str) -> list[str]:
+        """Return list of badges earned based on point thresholds."""
+        points = self.get_points(user_id)
+        badges = [name for threshold, name in self.BADGE_THRESHOLDS if points >= threshold]
+        return badges
 
 
 # Shared instance used across handlers


### PR DESCRIPTION
## Summary
- implement badge thresholds and helper to fetch earned badges
- add `/badges` command handler
- include badges router and update help text
- mention badges command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb68acf6c8329a053b185fcd562bf