### PR TITLE
Implement /ranking command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ python main.py
 - `/profile` shows a user's level, points and join date.
 - `/level` reports the current level and points.
 - `/badges` lists earned badges.
+- `/ranking` shows the top users by points.
 - `/help` explains available commands.
 - Basic echo handler for any other message.
 - `PointService` for registration and daily bonus points.

--- a/handlers/user/ranking.py
+++ b/handlers/user/ranking.py
@@ -1,0 +1,25 @@
+from aiogram import Router, F
+from aiogram.types import Message
+
+from services.point_service import point_service
+from services.user_service import get_user
+
+router = Router()
+
+
+@router.message(F.text == "/ranking")
+async def ranking_handler(message: Message) -> None:
+    user_id = str(message.from_user.id)
+    leaderboard = point_service.get_leaderboard(10)
+    lines = []
+    for position, (uid, points) in enumerate(leaderboard, start=1):
+        user = await get_user(int(uid))
+        name = user.full_name if user else uid
+        lines.append(f"{position}. {name} - {points}")
+
+    user_position = point_service.get_position(user_id)
+    user_points = point_service.get_points(user_id)
+
+    response = "Top 10 users:\n" + "\n".join(lines)
+    response += f"\n\nYour position: {user_position} with {user_points} points"
+    await message.answer(response)

--- a/main.py
+++ b/main.py
@@ -7,11 +7,13 @@ from handlers.user.start import router as start_router
 from handlers.user.profile import router as profile_router
 from handlers.user.level import router as level_router
 from handlers.user.badges import router as badges_router
+from handlers.user.ranking import router as ranking_router
 
 dp.include_router(start_router)
 dp.include_router(profile_router)
 dp.include_router(level_router)
 dp.include_router(badges_router)
+dp.include_router(ranking_router)
 
 
 @dp.message(Command("help"))

--- a/services/point_service.py
+++ b/services/point_service.py
@@ -39,6 +39,22 @@ class PointService:
         """Simple budget calculation derived from points."""
         return self.get_points(user_id) // 10
 
+    def get_leaderboard(self, limit: int = 10) -> list[tuple[str, int]]:
+        """Return top users sorted by points."""
+        return sorted(
+            self._points.items(), key=lambda x: x[1], reverse=True
+        )[:limit]
+
+    def get_position(self, user_id: str) -> int:
+        """Return the ranking position for a user (1-indexed)."""
+        sorted_users = sorted(
+            self._points.items(), key=lambda x: x[1], reverse=True
+        )
+        for index, (uid, _) in enumerate(sorted_users, start=1):
+            if uid == user_id:
+                return index
+        return len(sorted_users) + 1
+
 
 # Shared instance used across handlers
 point_service = PointService()


### PR DESCRIPTION
## Summary
- add a `/ranking` handler showing leaderboard and user ranking
- expose helper methods in `PointService`
- register ranking router in `main.py`
- document ranking command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bbf5e33388329a02209dd36674966