### PR TITLE
Add ranking system and leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python main.py
 - `/profile` shows a user's level, points and join date.
 - `/level` reports the current level and points.
 - `/badges` lists earned badges.
-- `/ranking` shows the top users by points.
+- `/ranking` or `/leaderboard` shows the top users by points.
 - `/help` explains available commands.
 - Basic echo handler for any other message.
 - `PointService` for registration and daily bonus points.

--- a/handlers/user/help.py
+++ b/handlers/user/help.py
@@ -1,11 +1,17 @@
-from aiogram import Router, F
+from aiogram import Router
+from aiogram.filters import Command
 from aiogram.types import Message
 
 router = Router()
 
 
-@router.message(F.text == "/help")
+@router.message(Command("help"))
 async def help_handler(message: Message) -> None:
     await message.answer(
-        "Use /profile to view your info, /level to see your level, /badges to list badges. Earn points daily"
+        "Available commands:\n"
+        "/profile - View your info\n"
+        "/level - Show your level and points\n"
+        "/badges - List your badges\n"
+        "/ranking - View the leaderboard"
+        " (alias: /leaderboard)"
     )

--- a/handlers/user/ranking.py
+++ b/handlers/user/ranking.py
@@ -1,4 +1,5 @@
-from aiogram import Router, F
+from aiogram import Router
+from aiogram.filters import Command
 from aiogram.types import Message
 
 from services.point_service import point_service
@@ -7,7 +8,8 @@ from services.user_service import get_user
 router = Router()
 
 
-@router.message(F.text == "/ranking")
+@router.message(Command("ranking"))
+@router.message(Command("leaderboard"))
 async def ranking_handler(message: Message) -> None:
     user_id = str(message.from_user.id)
     leaderboard = point_service.get_leaderboard(10)


### PR DESCRIPTION
## Summary
- support `/leaderboard` as alias to `/ranking`
- document leaderboard command
- update help text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bcdf46ae08329a39c4d205b8058ae