### PR TITLE
Add admin and configuration menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ python main.py
 - `/badges` lists earned badges.
 - `/ranking` or `/leaderboard` shows the top users by points.
 - `/help` explains available commands.
+- `/config` opens tariff configuration.
+- `/admin` provides administration tools.
 - Basic echo handler for any other message.
 - `PointService` for registration and daily bonus points.
 - Logging middleware writes errors to `logs/errors.log`.

--- a/handlers/admin/__init__.py
+++ b/handlers/admin/__init__.py
@@ -1,0 +1,4 @@
+from .configuration import router as configuration_router
+from .administration import router as administration_router
+
+__all__ = ["configuration_router", "administration_router"]

--- a/handlers/admin/administration.py
+++ b/handlers/admin/administration.py
@@ -1,0 +1,88 @@
+from aiogram import Router, F, types
+from aiogram.filters import Command
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from datetime import datetime
+import secrets
+
+from services.user_service import list_users, remove_user
+
+router = Router()
+
+
+@router.message(Command("admin"))
+async def admin_menu(message: types.Message) -> None:
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Estad\u00edsticas", callback_data="admin_stats")],
+            [InlineKeyboardButton(text="Broadcast", callback_data="admin_broadcast")],
+            [InlineKeyboardButton(text="Generar link", callback_data="admin_token")],
+            [InlineKeyboardButton(text="Suscriptores", callback_data="admin_subs")],
+        ]
+    )
+    await message.answer("Administraci\u00f3n", reply_markup=keyboard)
+
+
+@router.callback_query(F.data == "admin_stats")
+async def admin_stats(query: types.CallbackQuery) -> None:
+    users = await list_users()
+    await query.message.answer(f"Total de usuarios: {len(users)}")
+    await query.answer()
+
+
+@router.callback_query(F.data == "admin_token")
+async def admin_token(query: types.CallbackQuery) -> None:
+    token = secrets.token_urlsafe(16)
+    await query.message.answer(f"Link generado: https://t.me/tu_bot?start={token}")
+    await query.answer()
+
+
+@router.callback_query(F.data == "admin_broadcast")
+async def admin_broadcast(query: types.CallbackQuery) -> None:
+    await query.message.answer("Env\u00eda el mensaje con /broadcast <texto>")
+    await query.answer()
+
+
+@router.message(Command("broadcast"))
+async def broadcast_cmd(message: types.Message) -> None:
+    parts = message.text.split(maxsplit=1)
+    if len(parts) != 2:
+        await message.answer("Uso: /broadcast <mensaje>")
+        return
+    text = parts[1]
+    users = await list_users()
+    for u in users:
+        try:
+            await message.bot.send_message(u.id, text)
+        except Exception:
+            pass
+    await message.answer("Mensaje enviado.")
+
+
+@router.callback_query(F.data == "admin_subs")
+async def admin_subscribers(query: types.CallbackQuery) -> None:
+    users = await list_users()
+    if not users:
+        await query.message.answer("Sin suscriptores.")
+    for u in users:
+        days = (datetime.utcnow() - u.join_date).days
+        info = (
+            f"{u.full_name} - Ingres\u00f3 {u.join_date.date()} - "+
+            f"{days} d\u00edas - Renovaciones 0"
+        )
+        btn = InlineKeyboardMarkup(
+            inline_keyboard=[[
+                InlineKeyboardButton(
+                    text="Expulsar",
+                    callback_data=f"expulsar:{u.id}")
+            ]]
+        )
+        await query.message.answer(info, reply_markup=btn)
+    await query.answer()
+
+
+@router.callback_query(F.data.startswith("expulsar:"))
+async def expulsar_callback(query: types.CallbackQuery) -> None:
+    uid = int(query.data.split(":", 1)[1])
+    await remove_user(uid)
+    await query.message.answer(f"Usuario {uid} expulsado.")
+    await query.answer()

--- a/handlers/admin/configuration.py
+++ b/handlers/admin/configuration.py
@@ -1,0 +1,42 @@
+from aiogram import Router, F, types
+from aiogram.filters import Command
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services.config_service import get_config, set_config
+
+router = Router()
+
+
+@router.message(Command("config"))
+async def config_menu(message: types.Message) -> None:
+    """Show configuration menu."""
+    amount = await get_config("tariff_amount", "no establecido")
+    period = await get_config("tariff_period", "0")
+    text = f"Configuraci\u00f3n de tarifas actual: {amount} cada {period} d\u00edas"
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Configurar tarifas", callback_data="cfg_tariff")],
+        ]
+    )
+    await message.answer(text, reply_markup=keyboard)
+
+
+@router.callback_query(F.data == "cfg_tariff")
+async def cfg_tariff_callback(query: types.CallbackQuery) -> None:
+    await query.message.answer(
+        "Env\u00eda el comando /set_tarifa <monto> <dias> para establecer la tarifa"
+    )
+    await query.answer()
+
+
+@router.message(Command("set_tarifa"))
+async def set_tarifa(message: types.Message) -> None:
+    parts = message.text.split()
+    if len(parts) != 3:
+        await message.answer("Uso: /set_tarifa <monto> <dias>")
+        return
+    amount = parts[1]
+    period = parts[2]
+    await set_config("tariff_amount", amount)
+    await set_config("tariff_period", period)
+    await message.answer(f"Tarifa configurada en {amount} cada {period} d\u00edas")

--- a/main.py
+++ b/main.py
@@ -8,12 +8,15 @@ from handlers.user.profile import router as profile_router
 from handlers.user.level import router as level_router
 from handlers.user.badges import router as badges_router
 from handlers.user.ranking import router as ranking_router
+from handlers.admin import configuration_router, administration_router
 
 dp.include_router(start_router)
 dp.include_router(profile_router)
 dp.include_router(level_router)
 dp.include_router(badges_router)
 dp.include_router(ranking_router)
+dp.include_router(configuration_router)
+dp.include_router(administration_router)
 
 
 @dp.message(Command("help"))
@@ -25,6 +28,8 @@ async def help_handler(message: types.Message) -> None:
         "/profile - Show your profile\n"
         "/level - Get your level and points\n"
         "/badges - List your badges\n"
+        "/config - Configure tariffs\n"
+        "/admin - Administration menu\n"
         "/help - Show this message"
     )
     await message.answer(instructions)

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -1,0 +1,39 @@
+import sqlite3
+from typing import Any
+
+DB_PATH = 'bot.db'
+
+
+def _get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS config (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )"""
+    )
+    return conn
+
+
+async def set_config(key: str, value: str) -> None:
+    conn = _get_connection()
+    try:
+        with conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+                (key, value),
+            )
+    finally:
+        conn.close()
+
+
+async def get_config(key: str, default: Any | None = None) -> Any:
+    conn = _get_connection()
+    try:
+        cur = conn.execute("SELECT value FROM config WHERE key = ?", (key,))
+        row = cur.fetchone()
+        if row:
+            return row[0]
+        return default
+    finally:
+        conn.close()

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -59,3 +59,34 @@ async def get_user(user_id: int) -> User | None:
         )
     finally:
         conn.close()
+
+
+async def list_users() -> list[User]:
+    """Return all registered users."""
+    conn = _get_connection()
+    try:
+        cur = conn.execute(
+            "SELECT id, username, full_name, join_date FROM users ORDER BY join_date"
+        )
+        rows = cur.fetchall()
+        return [
+            User(
+                id=row[0],
+                username=row[1],
+                full_name=row[2],
+                join_date=datetime.fromisoformat(row[3]),
+            )
+            for row in rows
+        ]
+    finally:
+        conn.close()
+
+
+async def remove_user(user_id: int) -> None:
+    """Delete a user from the database."""
+    conn = _get_connection()
+    try:
+        with conn:
+            conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- store arbitrary bot config in SQLite
- list, remove, and broadcast to users
- add handlers for configuration and admin menus
- document new `/config` and `/admin` commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c8df255c08329b51125da17993bc7