### PR TITLE
Add aiogram bot base with user database

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,12 +1,7 @@
-from pydantic_settings import BaseSettings
+import os
+from dotenv import load_dotenv
 
+load_dotenv()
 
-class Settings(BaseSettings):
-    BOT_TOKEN: str
-
-    class Config:
-        env_file = '.env'
-        env_file_encoding = 'utf-8'
-
-
-settings = Settings()
+BOT_TOKEN = os.getenv("BOT_TOKEN", "")
+ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(',') if x]

--- a/db/database.py
+++ b/db/database.py
@@ -1,0 +1,61 @@
+import aiosqlite
+from datetime import datetime
+from typing import Optional, Dict
+
+DB_PATH = "bot.db"
+
+async def init_db() -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                user_id INTEGER PRIMARY KEY,
+                username TEXT,
+                full_name TEXT,
+                is_admin BOOLEAN DEFAULT 0,
+                join_date TEXT,
+                points INTEGER DEFAULT 0,
+                level INTEGER DEFAULT 1,
+                current_budget REAL DEFAULT 0.0,
+                last_reaction_date TEXT,
+                weekly_streak_permanence INTEGER DEFAULT 0,
+                total_spent REAL DEFAULT 0.0,
+                purchases_count INTEGER DEFAULT 0,
+                referrals_count INTEGER DEFAULT 0
+            )
+            """
+        )
+        await db.commit()
+
+async def create_user(user_id: int, username: str | None, full_name: str) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute("SELECT user_id FROM users WHERE user_id=?", (user_id,))
+        if await cursor.fetchone():
+            return
+        join_date = datetime.utcnow().isoformat()
+        await db.execute(
+            """
+            INSERT INTO users(user_id, username, full_name, join_date, points)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (user_id, username, full_name, join_date, 50),
+        )
+        await db.commit()
+
+async def get_user(user_id: int) -> Optional[Dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute("SELECT * FROM users WHERE user_id=?", (user_id,))
+        row = await cursor.fetchone()
+        if row:
+            columns = [col[0] for col in cursor.description]
+            return dict(zip(columns, row))
+        return None
+
+async def update_user_data(user_id: int, **kwargs) -> None:
+    if not kwargs:
+        return
+    fields = ", ".join(f"{k}=?" for k in kwargs)
+    values = list(kwargs.values()) + [user_id]
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(f"UPDATE users SET {fields} WHERE user_id=?", values)
+        await db.commit()

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,9 +1,9 @@
 from aiogram import Router
 
-from .start import router as start_router
+from .start_menu import router as start_menu_router
 
 
 def register_handlers() -> Router:
     router = Router()
-    router.include_router(start_router)
+    router.include_router(start_menu_router)
     return router

--- a/handlers/start_menu.py
+++ b/handlers/start_menu.py
@@ -1,0 +1,28 @@
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram import types
+
+from services.user_service import UserService
+from utils.keyboards import start_keyboard
+
+router = Router()
+user_service = UserService()
+
+
+@router.message(Command("start"))
+async def cmd_start(message: types.Message):
+    user = await user_service.register_user(
+        message.from_user.id,
+        message.from_user.username,
+        message.from_user.full_name,
+    )
+    is_admin = bool(user.get("is_admin")) if user else False
+    text = f"\u2705 Bienvenido {message.from_user.full_name}!"
+    await message.answer(text, reply_markup=start_keyboard(is_admin))
+
+
+@router.message(Command("menu"))
+async def cmd_menu(message: types.Message):
+    user = await user_service.get_user_profile(message.from_user.id)
+    is_admin = bool(user.get("is_admin")) if user else False
+    await message.answer("Men\u00fa", reply_markup=start_keyboard(is_admin))

--- a/main.py
+++ b/main.py
@@ -1,17 +1,40 @@
-import asyncio
+import logging
+from aiogram import Bot, Dispatcher
+from aiogram.enums import ParseMode
 
-from bot import bot, dp
+from config import BOT_TOKEN
 from handlers import register_handlers
+from middlewares.logging_middleware import LoggingMiddleware
+from db.database import init_db
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    handlers=[
+        logging.FileHandler("logs/errors.log"),
+        logging.StreamHandler()
+    ]
+)
+
+bot = Bot(token=BOT_TOKEN, parse_mode=ParseMode.HTML)
+dp = Dispatcher()
+dp.update.middleware(LoggingMiddleware())
 
 
 def register_all_handlers() -> None:
     dp.include_router(register_handlers())
 
 
-async def main() -> None:
+async def on_startup(bot: Bot) -> None:
+    await init_db()
+    logging.info("Bot started")
+
+
+async def on_shutdown(bot: Bot) -> None:
+    logging.info("Bot shutdown")
+
+
+if __name__ == "__main__":
     register_all_handlers()
-    await dp.start_polling(bot)
-
-
-if __name__ == '__main__':
-    asyncio.run(main())
+    dp.run_polling(bot, on_startup=on_startup, on_shutdown=on_shutdown)

--- a/middlewares/logging_middleware.py
+++ b/middlewares/logging_middleware.py
@@ -1,0 +1,13 @@
+import logging
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject
+
+
+class LoggingMiddleware(BaseMiddleware):
+    async def __call__(self, handler, event: TelegramObject, data: dict):
+        logging.info(f"Update: {event}")
+        try:
+            return await handler(event, data)
+        except Exception as e:
+            logging.exception("Error while processing update")
+            raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiogram>=3.0,<4.0
 pydantic>=2.0
 pydantic-settings>=2.0
 python-dotenv>=1.0
+aiosqlite>=0.19

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,0 +1,24 @@
+from typing import Optional, Dict
+
+from db import database
+
+
+class UserService:
+    async def register_user(self, user_id: int, username: str | None, full_name: str) -> Dict:
+        await database.create_user(user_id, username, full_name)
+        user = await database.get_user(user_id)
+        return user
+
+    async def get_user_profile(self, user_id: int) -> Optional[Dict]:
+        return await database.get_user(user_id)
+
+    async def update_user_points(self, user_id: int, delta: int) -> None:
+        user = await database.get_user(user_id)
+        if not user:
+            return
+        points = user.get("points", 0) + delta
+        await database.update_user_data(user_id, points=points)
+
+    async def is_admin(self, user_id: int) -> bool:
+        user = await database.get_user(user_id)
+        return bool(user and user.get("is_admin"))

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -1,0 +1,13 @@
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def start_keyboard(is_admin: bool = False) -> InlineKeyboardMarkup:
+    buttons = [[InlineKeyboardButton(text="Perfil", callback_data="profile")]]
+    if is_admin:
+        buttons.append([InlineKeyboardButton(text="Panel admin", callback_data="admin")])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def admin_keyboard() -> InlineKeyboardMarkup:
+    buttons = [[InlineKeyboardButton(text="Usuarios", callback_data="admin_users")]]
+    return InlineKeyboardMarkup(inline_keyboard=buttons)


### PR DESCRIPTION
## Summary
- configure environment variables for bot token and admins
- initialize bot and dispatcher with logging
- add sqlite helpers for users table
- create UserService CRUD wrapper
- implement /start and /menu handlers with inline keyboards
- add middleware for logging updates
- update requirements with aiosqlite

## Testing
- `python -m py_compile main.py handlers/start_menu.py services/user_service.py db/database.py middlewares/logging_middleware.py utils/keyboards.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_684db56744788329939d687ef95bcb20