### PR TITLE
Implement point and badge services

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -25,6 +25,36 @@ async def init_db() -> None:
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS levels (
+                level_id INTEGER PRIMARY KEY,
+                level_name TEXT,
+                min_points INTEGER,
+                max_points INTEGER,
+                benefits_description TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS badges (
+                badge_id INTEGER PRIMARY KEY,
+                name TEXT,
+                description TEXT,
+                image_url TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_badges (
+                user_id INTEGER,
+                badge_id INTEGER,
+                obtained_date TEXT
+            )
+            """
+        )
         await db.commit()
 
 async def create_user(user_id: int, username: str | None, full_name: str) -> None:
@@ -59,3 +89,64 @@ async def update_user_data(user_id: int, **kwargs) -> None:
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(f"UPDATE users SET {fields} WHERE user_id=?", values)
         await db.commit()
+
+
+async def get_level_for_points(points: int) -> Optional[Dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            """
+            SELECT * FROM levels
+            WHERE min_points<=? AND max_points>=?
+            ORDER BY level_id LIMIT 1
+            """,
+            (points, points),
+        )
+        row = await cursor.fetchone()
+        if row:
+            columns = [col[0] for col in cursor.description]
+            return dict(zip(columns, row))
+        return None
+
+
+async def get_next_level(points: int) -> Optional[Dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT * FROM levels WHERE min_points>? ORDER BY min_points LIMIT 1",
+            (points,),
+        )
+        row = await cursor.fetchone()
+        if row:
+            columns = [col[0] for col in cursor.description]
+            return dict(zip(columns, row))
+        return None
+
+
+async def get_top_users(limit: int = 10) -> list[Dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT * FROM users ORDER BY points DESC LIMIT ?",
+            (limit,),
+        )
+        rows = await cursor.fetchall()
+        columns = [col[0] for col in cursor.description]
+        return [dict(zip(columns, r)) for r in rows]
+
+
+async def get_user_rank_position(user_id: int) -> Optional[int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT points FROM users WHERE user_id=?",
+            (user_id,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        points = row[0]
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM users WHERE points>?",
+            (points,),
+        )
+        higher = await cursor.fetchone()
+        if higher:
+            return higher[0] + 1
+        return 1

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,9 +1,11 @@
 from aiogram import Router
 
 from .start_menu import router as start_menu_router
+from .profile_commands import router as profile_router
 
 
 def register_handlers() -> Router:
     router = Router()
     router.include_router(start_menu_router)
+    router.include_router(profile_router)
     return router

--- a/handlers/profile_commands.py
+++ b/handlers/profile_commands.py
@@ -1,0 +1,73 @@
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram import types
+
+from services.user_service import UserService
+from services.point_service import PointService
+from services.badge_service import BadgeService
+from db import database
+
+router = Router()
+user_service = UserService()
+point_service = PointService()
+badge_service = BadgeService()
+
+
+@router.message(Command("profile"))
+async def cmd_profile(message: types.Message):
+    user = await user_service.get_user_profile(message.from_user.id)
+    if not user:
+        await message.answer("Usuario no encontrado")
+        return
+    level_info = await point_service.calculate_level(user.get("points", 0))
+    badges = await badge_service.get_user_badges(message.from_user.id)
+    badges_text = ", ".join(b["name"] for b in badges) if badges else "Ninguna"
+    level_name = level_info[1] if level_info else "-"
+    text = (
+        f"\ud83d\udc64 <b>{user.get('full_name')}</b>\n"
+        f"Nivel: <b>{level_name}</b>\n"
+        f"Puntos: <b>{user.get('points')}</b>\n"
+        f"Presupuesto actual: <b>{user.get('current_budget')}</b>\n"
+        f"Fecha de registro: <b>{user.get('join_date')}</b>\n"
+        f"Insignias: {badges_text}"
+    )
+    await message.answer(text)
+
+
+@router.message(Command("level"))
+async def cmd_level(message: types.Message):
+    user = await user_service.get_user_profile(message.from_user.id)
+    if not user:
+        await message.answer("Usuario no encontrado")
+        return
+    level = await point_service.calculate_level(user.get("points", 0))
+    next_level = await database.get_next_level(user.get("points", 0))
+    if next_level:
+        progress = f"{user.get('points')}/{next_level['min_points']}"
+    else:
+        progress = "Maximo nivel"
+    level_name = level[1] if level else "-"
+    await message.answer(
+        f"Nivel actual: <b>{level_name}</b>\nPuntos: {user.get('points')}\nProgreso: {progress}"
+    )
+
+
+@router.message(Command("badges"))
+async def cmd_badges(message: types.Message):
+    user_badges = await badge_service.get_user_badges(message.from_user.id)
+    if not user_badges:
+        await message.answer("A\u00fan no tienes insignias")
+        return
+    lines = [f"\u2022 {b['name']}" for b in user_badges]
+    await message.answer("Insignias obtenidas:\n" + "\n".join(lines))
+
+
+@router.message(Command("ranking"))
+@router.message(Command("leaderboard"))
+async def cmd_ranking(message: types.Message):
+    top_users = await point_service.get_top_users(10)
+    lines = []
+    for idx, user in enumerate(top_users, start=1):
+        name = user.get("full_name") or user.get("username") or user.get("user_id")
+        lines.append(f"{idx}. {name} - {user.get('points')} pts")
+    await message.answer("\uD83C\uDFC6 Ranking:\n" + "\n".join(lines))

--- a/services/badge_service.py
+++ b/services/badge_service.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from typing import List, Dict
+
+import aiosqlite
+from db.database import DB_PATH
+
+
+class BadgeService:
+    async def award_badge(self, user_id: int, badge_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "INSERT INTO user_badges(user_id, badge_id, obtained_date) VALUES (?, ?, ?)",
+                (user_id, badge_id, datetime.utcnow().isoformat()),
+            )
+            await db.commit()
+
+    async def get_user_badges(self, user_id: int) -> List[Dict]:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                """
+                SELECT b.badge_id, b.name, b.description, b.image_url, ub.obtained_date
+                FROM user_badges ub
+                JOIN badges b ON ub.badge_id = b.badge_id
+                WHERE ub.user_id=?
+                """,
+                (user_id,),
+            )
+            rows = await cursor.fetchall()
+            columns = [c[0] for c in cursor.description]
+            return [dict(zip(columns, r)) for r in rows]
+
+    async def check_level_badge(self, user_id: int, level_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM user_badges WHERE user_id=? AND badge_id=?",
+                (user_id, level_id),
+            )
+            if await cursor.fetchone():
+                return
+            cursor = await db.execute(
+                "SELECT badge_id FROM badges WHERE badge_id=?",
+                (level_id,),
+            )
+            if await cursor.fetchone():
+                await self.award_badge(user_id, level_id)

--- a/services/point_service.py
+++ b/services/point_service.py
@@ -1,0 +1,56 @@
+from typing import Optional, Tuple, List, Dict
+
+from db import database
+from .badge_service import BadgeService
+
+
+class PointService:
+    def __init__(self) -> None:
+        self.badge_service = BadgeService()
+
+    async def add_points(self, user_id: int, amount: int, reason: str | None = None) -> None:
+        user = await database.get_user(user_id)
+        if not user:
+            return
+        points = user.get("points", 0) + amount
+        budget = user.get("current_budget", 0.0) + amount
+        await database.update_user_data(user_id, points=points, current_budget=budget)
+        await self.check_and_update_level(user_id)
+
+    async def deduct_points(self, user_id: int, amount: int, reason: str | None = None) -> bool:
+        user = await database.get_user(user_id)
+        if not user:
+            return False
+        if user.get("current_budget", 0.0) < amount:
+            return False
+        points = max(0, user.get("points", 0) - amount)
+        budget = user.get("current_budget", 0.0) - amount
+        await database.update_user_data(user_id, points=points, current_budget=budget)
+        return True
+
+    async def check_and_update_level(self, user_id: int) -> Optional[Tuple[int, str]]:
+        user = await database.get_user(user_id)
+        if not user:
+            return None
+        current_points = user.get("points", 0)
+        level_info = await self.calculate_level(current_points)
+        if not level_info:
+            return None
+        new_level = level_info[0]
+        if new_level != user.get("level"):
+            await database.update_user_data(user_id, level=new_level)
+            await self.badge_service.check_level_badge(user_id, new_level)
+            return level_info
+        return None
+
+    async def calculate_level(self, points: int) -> Optional[Tuple[int, str]]:
+        level = await database.get_level_for_points(points)
+        if level:
+            return level["level_id"], level["level_name"]
+        return None
+
+    async def get_user_ranking_position(self, user_id: int) -> Optional[int]:
+        return await database.get_user_rank_position(user_id)
+
+    async def get_top_users(self, limit: int = 10) -> List[Dict]:
+        return await database.get_top_users(limit)


### PR DESCRIPTION
## Summary
- set up levels, badges and user_badges tables
- expose helpers for ranking and level lookups
- implement `PointService` and `BadgeService`
- add profile and ranking commands
- register the new handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684db6df97188329a8d48a5985780c4d