### PR TITLE
Implement reactions, polls and cron job base

### DIFF
--- a/cron_jobs.py
+++ b/cron_jobs.py
@@ -1,0 +1,64 @@
+import asyncio
+from datetime import datetime
+
+import aiosqlite
+
+from db.database import DB_PATH
+from services.point_service import PointService
+from services.badge_service import BadgeService
+
+
+class Scheduler:
+    def __init__(self) -> None:
+        self.jobs: list[callable] = []
+
+    def add_daily_job(self, coro):
+        self.jobs.append(coro)
+
+    async def start(self, bot):
+        while True:
+            for job in self.jobs:
+                try:
+                    await job(bot)
+                except Exception:
+                    pass
+            await asyncio.sleep(24 * 60 * 60)
+
+
+async def daily_reset_interaction_limit(bot) -> None:
+    today = datetime.utcnow().date().isoformat()
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE daily_interaction_limits SET interaction_count=0, last_reset_date=?",
+            (today,),
+        )
+        await db.commit()
+
+
+async def award_permanence_points_job(bot) -> None:
+    point_service = PointService()
+    badge_service = BadgeService()
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT user_id, weekly_streak_permanence FROM users"
+        )
+        rows = await cursor.fetchall()
+        badge_id = None
+        cur = await db.execute(
+            "SELECT badge_id FROM badges WHERE name=?",
+            ("Veterano \u00cdntimo",),
+        )
+        row = await cur.fetchone()
+        if row:
+            badge_id = row[0]
+        for user_id, streak in rows:
+            await point_service.add_points(user_id, 1, reason="permanence")
+            new_streak = (streak or 0) + 1
+            await db.execute(
+                "UPDATE users SET weekly_streak_permanence=? WHERE user_id=?",
+                (new_streak, user_id),
+            )
+            if badge_id and new_streak % 7 == 0:
+                await badge_service.award_badge(user_id, badge_id)
+        await db.commit()
+

--- a/db/database.py
+++ b/db/database.py
@@ -55,6 +55,51 @@ async def init_db() -> None:
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reactions_log (
+                log_id INTEGER PRIMARY KEY,
+                message_id INTEGER,
+                user_id INTEGER,
+                reaction_type TEXT,
+                reaction_date TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS daily_interaction_limits (
+                user_id INTEGER PRIMARY KEY,
+                interaction_count INTEGER,
+                last_reset_date TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS polls (
+                poll_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                question TEXT,
+                creator_id INTEGER,
+                message_id INTEGER,
+                yes_count INTEGER DEFAULT 0,
+                no_count INTEGER DEFAULT 0,
+                is_active BOOLEAN DEFAULT 1,
+                created_at TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS poll_votes (
+                vote_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                poll_id INTEGER,
+                user_id INTEGER,
+                vote_type TEXT,
+                voted_at TEXT
+            )
+            """
+        )
         await db.commit()
 
 async def create_user(user_id: int, username: str | None, full_name: str) -> None:

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -2,10 +2,12 @@ from aiogram import Router
 
 from .start_menu import router as start_menu_router
 from .profile_commands import router as profile_router
+from .interaction_handlers import router as interaction_router
 
 
 def register_handlers() -> Router:
     router = Router()
     router.include_router(start_menu_router)
     router.include_router(profile_router)
+    router.include_router(interaction_router)
     return router

--- a/handlers/interaction_handlers.py
+++ b/handlers/interaction_handlers.py
@@ -1,0 +1,94 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from config import ADMIN_IDS
+from services.reaction_service import ReactionService
+from services.poll_service import PollService
+
+
+router = Router()
+reaction_service = ReactionService()
+poll_service = PollService()
+
+
+@router.message(Command("feedback"))
+async def cmd_feedback(message: types.Message):
+    kb = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                types.InlineKeyboardButton(text="🔥", callback_data="reaction_🔥"),
+                types.InlineKeyboardButton(text="👍", callback_data="reaction_👍"),
+            ]
+        ]
+    )
+    await message.answer("Deja tu reacci\u00f3n", reply_markup=kb)
+
+
+@router.callback_query(lambda c: c.data and c.data.startswith("reaction_"))
+async def handle_reaction(callback: types.CallbackQuery):
+    reaction = callback.data.split("_")[1]
+    user_id = callback.from_user.id
+    can = await reaction_service.can_react_today(user_id)
+    if not can:
+        await callback.answer("L\u00edmite diario alcanzado", show_alert=True)
+        return
+    await reaction_service.record_reaction(callback.message.message_id, user_id, reaction)
+    await reaction_service.award_reaction_points(user_id)
+    await callback.answer("\u2705 Registrado")
+
+
+@router.message(Command("poll"))
+async def cmd_poll(message: types.Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Debes proporcionar la pregunta")
+        return
+    question = parts[1]
+    poll_id = await poll_service.create_poll(question, message.from_user.id)
+    kb = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                types.InlineKeyboardButton(text="S\u00ed", callback_data=f"poll_yes_{poll_id}"),
+                types.InlineKeyboardButton(text="No", callback_data=f"poll_no_{poll_id}"),
+            ],
+            [
+                types.InlineKeyboardButton(text="Cerrar encuesta", callback_data=f"close_poll_{poll_id}")
+            ],
+        ]
+    )
+    sent = await message.answer(question, reply_markup=kb)
+    await poll_service.update_poll_message_id(poll_id, sent.message_id)
+
+
+@router.callback_query(lambda c: c.data and (c.data.startswith("poll_yes_") or c.data.startswith("poll_no_")))
+async def handle_poll_vote(callback: types.CallbackQuery):
+    parts = callback.data.split("_")
+    vote = parts[1]
+    poll_id = int(parts[2])
+    recorded = await poll_service.record_vote(poll_id, callback.from_user.id, vote)
+    if not recorded:
+        await callback.answer("Ya has votado o la encuesta est\u00e1 cerrada", show_alert=True)
+        return
+    await poll_service.award_poll_points(callback.from_user.id)
+    await callback.answer("Voto registrado")
+
+
+@router.callback_query(lambda c: c.data and c.data.startswith("close_poll_"))
+async def handle_close_poll(callback: types.CallbackQuery):
+    if callback.from_user.id not in ADMIN_IDS:
+        await callback.answer()
+        return
+    poll_id = int(callback.data.split("_")[2])
+    await poll_service.deactivate_poll(poll_id)
+    results = await poll_service.get_poll_results(poll_id)
+    if results:
+        yes_count, no_count = results
+        text = f"Resultados: S\u00ed {yes_count} - No {no_count}"
+    else:
+        text = "Sin resultados"
+    await callback.message.edit_reply_markup()
+    await callback.message.answer(text)
+    await callback.answer("Encuesta cerrada")
+

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from config import BOT_TOKEN
 from handlers import register_handlers
 from middlewares.logging_middleware import LoggingMiddleware
 from db.database import init_db
+from cron_jobs import Scheduler, daily_reset_interaction_limit, award_permanence_points_job
 
 
 logging.basicConfig(
@@ -20,6 +21,7 @@ logging.basicConfig(
 bot = Bot(token=BOT_TOKEN, parse_mode=ParseMode.HTML)
 dp = Dispatcher()
 dp.update.middleware(LoggingMiddleware())
+scheduler = Scheduler()
 
 
 def register_all_handlers() -> None:
@@ -28,6 +30,9 @@ def register_all_handlers() -> None:
 
 async def on_startup(bot: Bot) -> None:
     await init_db()
+    scheduler.add_daily_job(daily_reset_interaction_limit)
+    scheduler.add_daily_job(award_permanence_points_job)
+    dp.loop.create_task(scheduler.start(bot))
     logging.info("Bot started")
 
 

--- a/services/poll_service.py
+++ b/services/poll_service.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+import aiosqlite
+
+from db.database import DB_PATH
+from .point_service import PointService
+
+
+class PollService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+
+    async def create_poll(self, question: str, creator_id: int, message_id: int | None = None) -> int:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "INSERT INTO polls(question, creator_id, message_id, created_at) VALUES (?,?,?,?)",
+                (question, creator_id, message_id, datetime.utcnow().isoformat()),
+            )
+            await db.commit()
+            return cursor.lastrowid
+
+    async def update_poll_message_id(self, poll_id: int, message_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "UPDATE polls SET message_id=? WHERE poll_id=?",
+                (message_id, poll_id),
+            )
+            await db.commit()
+
+    async def record_vote(self, poll_id: int, user_id: int, vote_type: str) -> bool:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT is_active FROM polls WHERE poll_id=?",
+                (poll_id,),
+            )
+            poll_row = await cursor.fetchone()
+            if not poll_row or not poll_row[0]:
+                return False
+            cursor = await db.execute(
+                "SELECT 1 FROM poll_votes WHERE poll_id=? AND user_id=?",
+                (poll_id, user_id),
+            )
+            if await cursor.fetchone():
+                return False
+            await db.execute(
+                "INSERT INTO poll_votes(poll_id, user_id, vote_type, voted_at) VALUES (?,?,?,?)",
+                (poll_id, user_id, vote_type, datetime.utcnow().isoformat()),
+            )
+            column = "yes_count" if vote_type == "yes" else "no_count"
+            await db.execute(
+                f"UPDATE polls SET {column}={column}+1 WHERE poll_id=?",
+                (poll_id,),
+            )
+            await db.commit()
+            return True
+
+    async def get_poll_results(self, poll_id: int) -> tuple[int, int] | None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT yes_count, no_count FROM polls WHERE poll_id=?",
+                (poll_id,),
+            )
+            row = await cursor.fetchone()
+            if row:
+                return row[0], row[1]
+            return None
+
+    async def deactivate_poll(self, poll_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "UPDATE polls SET is_active=0 WHERE poll_id=?",
+                (poll_id,),
+            )
+            await db.commit()
+
+    async def award_poll_points(self, user_id: int) -> None:
+        await self.point_service.add_points(user_id, 5, reason="poll_vote")
+

--- a/services/reaction_service.py
+++ b/services/reaction_service.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+import aiosqlite
+
+from db.database import DB_PATH, update_user_data
+from .point_service import PointService
+
+
+class ReactionService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+
+    async def _increment_interaction(self, user_id: int, db):
+        today = datetime.utcnow().date().isoformat()
+        cursor = await db.execute(
+            "SELECT interaction_count, last_reset_date FROM daily_interaction_limits WHERE user_id=?",
+            (user_id,),
+        )
+        row = await cursor.fetchone()
+        if row:
+            count, last_reset = row
+            if last_reset != today:
+                count = 0
+                await db.execute(
+                    "UPDATE daily_interaction_limits SET interaction_count=0, last_reset_date=? WHERE user_id=?",
+                    (today, user_id),
+                )
+            await db.execute(
+                "UPDATE daily_interaction_limits SET interaction_count=? WHERE user_id=?",
+                (count + 1, user_id),
+            )
+        else:
+            await db.execute(
+                "INSERT INTO daily_interaction_limits(user_id, interaction_count, last_reset_date) VALUES (?,?,?)",
+                (user_id, 1, today),
+            )
+
+    async def can_react_today(self, user_id: int) -> bool:
+        today = datetime.utcnow().date().isoformat()
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT interaction_count, last_reset_date FROM daily_interaction_limits WHERE user_id=?",
+                (user_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return True
+            count, last_reset = row
+            if last_reset != today:
+                return True
+            return count < 4  # 4 interactions * 5 points = 20
+
+    async def record_reaction(self, message_id: int, user_id: int, reaction_type: str) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "INSERT INTO reactions_log(message_id, user_id, reaction_type, reaction_date) VALUES (?,?,?,?)",
+                (message_id, user_id, reaction_type, datetime.utcnow().isoformat()),
+            )
+            await self._increment_interaction(user_id, db)
+            await db.commit()
+
+    async def award_reaction_points(self, user_id: int) -> None:
+        await self.point_service.add_points(user_id, 5, reason="reaction")
+        await update_user_data(user_id, last_reaction_date=datetime.utcnow().isoformat())
+


### PR DESCRIPTION
## Summary
- extend DB with reactions, poll and daily interaction tables
- add services for reactions and polls
- handle feedback reactions and polls via new handlers
- create simple scheduler with daily jobs
- integrate new handlers and scheduler in main app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684db8eb129c832988a163205d4e1b87