### PR TITLE
Add purchases, rewards and missions modules

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -100,6 +100,63 @@ async def init_db() -> None:
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS purchases (
+                purchase_id INTEGER PRIMARY KEY,
+                user_id INTEGER,
+                amount_mxn REAL,
+                points_awarded INTEGER,
+                purchase_date TEXT,
+                is_renewal BOOLEAN,
+                is_early_renewal BOOLEAN
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rewards (
+                reward_id INTEGER PRIMARY KEY,
+                name TEXT,
+                cost_points INTEGER,
+                description TEXT,
+                reward_type TEXT,
+                content_data TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_rewards (
+                user_id INTEGER,
+                reward_id INTEGER,
+                purchase_date TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS missions (
+                mission_id INTEGER PRIMARY KEY,
+                type TEXT,
+                description TEXT,
+                points_reward INTEGER,
+                completion_criteria TEXT,
+                active_from TEXT,
+                active_until TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_missions (
+                user_id INTEGER,
+                mission_id INTEGER,
+                completed BOOLEAN,
+                completion_date TEXT
+            )
+            """
+        )
         await db.commit()
 
 async def create_user(user_id: int, username: str | None, full_name: str) -> None:

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -3,6 +3,8 @@ from aiogram import Router
 from .start_menu import router as start_menu_router
 from .profile_commands import router as profile_router
 from .interaction_handlers import router as interaction_router
+from .admin_commands import router as admin_router
+from .user_commands import router as user_cmd_router
 
 
 def register_handlers() -> Router:
@@ -10,4 +12,6 @@ def register_handlers() -> Router:
     router.include_router(start_menu_router)
     router.include_router(profile_router)
     router.include_router(interaction_router)
+    router.include_router(admin_router)
+    router.include_router(user_cmd_router)
     return router

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -1,0 +1,58 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from config import ADMIN_IDS
+from services.purchase_service import PurchaseService
+from services.point_service import PointService
+from services.mission_service import MissionService
+
+router = Router()
+purchase_service = PurchaseService()
+point_service = PointService()
+mission_service = MissionService()
+
+
+@router.message(Command("sumarpuntos"))
+async def cmd_sumarpuntos(message: types.Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    parts = message.text.split()
+    if len(parts) < 3:
+        await message.answer("Uso: /sumarpuntos [ID_usuario] [monto_MXN]")
+        return
+    try:
+        user_id = int(parts[1])
+        amount = float(parts[2])
+    except ValueError:
+        await message.answer("Valores invalidos")
+        return
+    await purchase_service.record_purchase(user_id, amount)
+    await purchase_service.award_purchase_points(user_id, amount)
+    await purchase_service.check_bonus_purchases(user_id)
+    await message.answer("Compra registrada y puntos otorgados")
+
+
+@router.message(Command("crearmision"))
+async def cmd_crear_mision(message: types.Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    parts = message.text.split(maxsplit=6)
+    if len(parts) < 7:
+        await message.answer("Uso: /crearmision tipo descripcion puntos criterio desde hasta")
+        return
+    _, m_type, desc, points, criteria, active_from, active_until = parts
+    mission_id = await mission_service.create_mission(m_type, desc, int(points), criteria, active_from, active_until)
+    await message.answer(f"Mision creada ID {mission_id}")
+
+
+@router.message(Command("activarmision"))
+async def cmd_activar_mision(message: types.Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    parts = message.text.split()
+    if len(parts) < 2:
+        await message.answer("Uso: /activarmision [ID]")
+        return
+    mission_id = int(parts[1])
+    await mission_service.activate_mission(mission_id)
+    await message.answer("Mision activada")

--- a/handlers/user_commands.py
+++ b/handlers/user_commands.py
@@ -1,0 +1,32 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from services.reward_service import RewardService
+
+router = Router()
+reward_service = RewardService()
+
+
+@router.message(Command("catalogo"))
+async def cmd_catalogo(message: types.Message):
+    rewards = await reward_service.get_all_rewards()
+    if not rewards:
+        await message.answer("No hay recompensas disponibles")
+        return
+    lines = [f"{r['reward_id']}. {r['name']} - {r['cost_points']} pts" for r in rewards]
+    await message.answer("Catalogo de recompensas:\n" + "\n".join(lines))
+
+
+@router.message(Command("canjear"))
+async def cmd_canjear(message: types.Message, bot):
+    parts = message.text.split()
+    if len(parts) < 2:
+        await message.answer("Uso: /canjear [ID_recompensa]")
+        return
+    reward_id = int(parts[1])
+    success = await reward_service.redeem_reward(message.from_user.id, reward_id)
+    if not success:
+        await message.answer("No tienes puntos suficientes o recompensa invalida")
+        return
+    await reward_service.deliver_reward(message.from_user.id, reward_id, bot)
+    await message.answer("Recompensa canjeada")

--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ from config import BOT_TOKEN
 from handlers import register_handlers
 from middlewares.logging_middleware import LoggingMiddleware
 from db.database import init_db
-from cron_jobs import Scheduler, daily_reset_interaction_limit, award_permanence_points_job
+from cron_jobs import (
+    Scheduler,
+    daily_reset_interaction_limit,
+    award_permanence_points_job,
+    check_and_award_missions,
+)
 
 
 logging.basicConfig(
@@ -32,6 +37,7 @@ async def on_startup(bot: Bot) -> None:
     await init_db()
     scheduler.add_daily_job(daily_reset_interaction_limit)
     scheduler.add_daily_job(award_permanence_points_job)
+    scheduler.add_daily_job(check_and_award_missions)
     dp.loop.create_task(scheduler.start(bot))
     logging.info("Bot started")
 

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from typing import Dict
+
+import aiosqlite
+
+from db.database import DB_PATH
+from .point_service import PointService
+
+
+class MissionService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+
+    async def create_mission(
+        self,
+        type: str,
+        description: str,
+        points_reward: int,
+        completion_criteria: str,
+        active_from: str,
+        active_until: str,
+    ) -> int:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                """
+                INSERT INTO missions(type, description, points_reward, completion_criteria, active_from, active_until)
+                VALUES (?,?,?,?,?,?)
+                """,
+                (type, description, points_reward, completion_criteria, active_from, active_until),
+            )
+            await db.commit()
+            return cursor.lastrowid
+
+    async def activate_mission(self, mission_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "UPDATE missions SET active_from=? WHERE mission_id=?",
+                (datetime.utcnow().isoformat(), mission_id),
+            )
+            await db.commit()
+
+    async def check_user_mission_completion(self, user_id: int, mission_id: int, current_data: Dict) -> bool:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT completion_criteria FROM missions WHERE mission_id=?",
+                (mission_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return False
+            criteria = row[0]
+        try:
+            required = int(criteria)
+            value = int(current_data.get("value", 0))
+            return value >= required
+        except Exception:
+            return False
+
+    async def complete_mission(self, user_id: int, mission_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT points_reward FROM missions WHERE mission_id=?",
+                (mission_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return
+            points = row[0]
+        await self.point_service.add_points(user_id, points, reason="mission")
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "INSERT INTO user_missions(user_id, mission_id, completed, completion_date) VALUES (?,?,?,?)",
+                (user_id, mission_id, True, datetime.utcnow().isoformat()),
+            )
+            await db.commit()

--- a/services/purchase_service.py
+++ b/services/purchase_service.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+import aiosqlite
+
+from db.database import DB_PATH, get_user, update_user_data
+from .point_service import PointService
+
+
+class PurchaseService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+
+    async def record_purchase(self, user_id: int, amount_mxn: float, is_renewal: bool = False, is_early_renewal: bool = False) -> int:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "INSERT INTO purchases(user_id, amount_mxn, points_awarded, purchase_date, is_renewal, is_early_renewal) VALUES (?,?,?,?,?,?)",
+                (user_id, amount_mxn, 0, datetime.utcnow().isoformat(), is_renewal, is_early_renewal),
+            )
+            await db.commit()
+            purchase_id = cursor.lastrowid
+        user = await get_user(user_id)
+        if user:
+            total = (user.get("total_spent", 0.0) or 0.0) + amount_mxn
+            count = (user.get("purchases_count", 0) or 0) + 1
+            await update_user_data(user_id, total_spent=total, purchases_count=count)
+        return purchase_id
+
+    async def award_purchase_points(self, user_id: int, amount_mxn: float) -> int:
+        points = int(amount_mxn)
+        await self.point_service.add_points(user_id, points, reason="purchase")
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "UPDATE purchases SET points_awarded=? WHERE user_id=? AND points_awarded=0 ORDER BY purchase_id DESC LIMIT 1",
+                (points, user_id),
+            )
+            await db.commit()
+        return points
+
+    async def check_bonus_purchases(self, user_id: int) -> None:
+        user = await get_user(user_id)
+        if not user:
+            return
+        if user.get("purchases_count", 0) == 5:
+            await self.point_service.add_points(user_id, 50, reason="bonus_5_purchases")
+        if user.get("total_spent", 0) >= 10000:
+            await self.point_service.add_points(user_id, 100, reason="big_spender_vip")

--- a/services/reward_service.py
+++ b/services/reward_service.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from typing import List, Dict
+
+import aiosqlite
+from aiogram import Bot
+
+from db.database import DB_PATH, get_user
+from .point_service import PointService
+from .badge_service import BadgeService
+
+
+class RewardService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+        self.badge_service = BadgeService()
+
+    async def get_all_rewards(self) -> List[Dict]:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute("SELECT * FROM rewards")
+            rows = await cursor.fetchall()
+            cols = [c[0] for c in cursor.description]
+            return [dict(zip(cols, r)) for r in rows]
+
+    async def can_afford(self, user_id: int, reward_id: int) -> bool:
+        user = await get_user(user_id)
+        if not user:
+            return False
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute("SELECT cost_points FROM rewards WHERE reward_id=?", (reward_id,))
+            row = await cursor.fetchone()
+            if not row:
+                return False
+            cost = row[0]
+        return user.get("current_budget", 0) >= cost
+
+    async def redeem_reward(self, user_id: int, reward_id: int) -> bool:
+        if not await self.can_afford(user_id, reward_id):
+            return False
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute("SELECT cost_points FROM rewards WHERE reward_id=?", (reward_id,))
+            row = await cursor.fetchone()
+            if not row:
+                return False
+            cost = row[0]
+        success = await self.point_service.deduct_points(user_id, cost)
+        if not success:
+            return False
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "INSERT INTO user_rewards(user_id, reward_id, purchase_date) VALUES (?,?,?)",
+                (user_id, reward_id, datetime.utcnow().isoformat()),
+            )
+            await db.commit()
+        await self.award_first_redeem_badge(user_id)
+        return True
+
+    async def deliver_reward(self, user_id: int, reward_id: int, bot: Bot) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT reward_type, content_data FROM rewards WHERE reward_id=?",
+                (reward_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return
+            r_type, content = row
+        if r_type == "text":
+            await bot.send_message(user_id, content)
+        elif r_type == "file":
+            await bot.send_document(user_id, content)
+        else:
+            await bot.send_message(user_id, "Recompensa entregada")
+
+    async def award_first_redeem_badge(self, user_id: int) -> None:
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM user_rewards WHERE user_id=?",
+                (user_id,),
+            )
+            row = await cursor.fetchone()
+            if row and row[0] == 1:
+                cur = await db.execute(
+                    "SELECT badge_id FROM badges WHERE name=?",
+                    ("Primer Canje",),
+                )
+                b_row = await cur.fetchone()
+                if b_row:
+                    await self.badge_service.award_badge(user_id, b_row[0])


### PR DESCRIPTION
## Summary
- create new tables in database for purchases, rewards and missions
- implement `PurchaseService`, `RewardService` and `MissionService`
- add admin handlers for purchases and missions
- add user handlers for reward catalog and redemption
- run new daily cron job for mission rewards
- register new handlers and cron job in main

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dbe615bdc8329bf1606c1fe196256