### PR TITLE
Add inline menu with new reward options

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -136,6 +136,14 @@ async def init_db() -> None:
         )
         await db.execute(
             """
+            CREATE TABLE IF NOT EXISTS daily_rewards (
+                user_id INTEGER PRIMARY KEY,
+                last_claim_date TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
             CREATE TABLE IF NOT EXISTS missions (
                 mission_id INTEGER PRIMARY KEY,
                 type TEXT,
@@ -252,3 +260,34 @@ async def get_user_rank_position(user_id: int) -> Optional[int]:
         if higher:
             return higher[0] + 1
         return 1
+
+
+async def get_last_daily_claim(user_id: int) -> Optional[str]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT last_claim_date FROM daily_rewards WHERE user_id=?",
+            (user_id,),
+        )
+        row = await cursor.fetchone()
+        if row:
+            return row[0]
+        return None
+
+
+async def update_daily_claim(user_id: int, claim_date: str) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT 1 FROM daily_rewards WHERE user_id=?",
+            (user_id,),
+        )
+        if await cursor.fetchone():
+            await db.execute(
+                "UPDATE daily_rewards SET last_claim_date=? WHERE user_id=?",
+                (claim_date, user_id),
+            )
+        else:
+            await db.execute(
+                "INSERT INTO daily_rewards(user_id, last_claim_date) VALUES (?,?)",
+                (user_id, claim_date),
+            )
+        await db.commit()

--- a/handlers/start_menu.py
+++ b/handlers/start_menu.py
@@ -3,10 +3,18 @@ from aiogram.filters import Command
 from aiogram import types
 
 from services.user_service import UserService
+from services.point_service import PointService
+from services.badge_service import BadgeService
+from services.daily_reward_service import DailyRewardService
+from services.mission_service import MissionService
 from utils.keyboards import start_keyboard
 
 router = Router()
 user_service = UserService()
+point_service = PointService()
+badge_service = BadgeService()
+daily_reward_service = DailyRewardService()
+mission_service = MissionService()
 
 
 @router.message(Command("start"))
@@ -26,3 +34,49 @@ async def cmd_menu(message: types.Message):
     user = await user_service.get_user_profile(message.from_user.id)
     is_admin = bool(user.get("is_admin")) if user else False
     await message.answer("Men\u00fa", reply_markup=start_keyboard(is_admin))
+
+
+@router.callback_query(lambda c: c.data == "profile")
+async def cb_profile(callback: types.CallbackQuery):
+    user = await user_service.get_user_profile(callback.from_user.id)
+    if not user:
+        await callback.message.answer("Usuario no encontrado")
+        await callback.answer()
+        return
+    level_info = await point_service.calculate_level(user.get("points", 0))
+    badges = await badge_service.get_user_badges(callback.from_user.id)
+    badges_text = ", ".join(b["name"] for b in badges) if badges else "Ninguna"
+    level_name = level_info[1] if level_info else "-"
+    text = (
+        f"\U0001F464 <b>{user.get('full_name')}</b>\n"
+        f"Nivel: <b>{level_name}</b>\n"
+        f"Puntos: <b>{user.get('points')}</b>\n"
+        f"Presupuesto actual: <b>{user.get('current_budget')}</b>\n"
+        f"Fecha de registro: <b>{user.get('join_date')}</b>\n"
+        f"Insignias: {badges_text}"
+    )
+    await callback.message.answer(text)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "daily_reward")
+async def cb_daily_reward(callback: types.CallbackQuery):
+    claimed = await daily_reward_service.claim_reward(callback.from_user.id)
+    if claimed:
+        await callback.message.answer("Has recibido 10 puntos de recompensa diaria!")
+    else:
+        await callback.answer("Ya reclamaste tu recompensa hoy", show_alert=True)
+        return
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "weekly_task")
+async def cb_weekly_task(callback: types.CallbackQuery):
+    mission = await mission_service.get_active_mission()
+    if not mission:
+        await callback.message.answer("No hay tarea semanal activa")
+    else:
+        desc = mission.get("description")
+        pts = mission.get("points_reward")
+        await callback.message.answer(f"Tarea semanal: {desc}\nRecompensa: {pts} puntos")
+    await callback.answer()

--- a/services/daily_reward_service.py
+++ b/services/daily_reward_service.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from db import database
+from .point_service import PointService
+
+
+class DailyRewardService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+
+    async def claim_reward(self, user_id: int) -> bool:
+        today = datetime.utcnow().date().isoformat()
+        last_claim = await database.get_last_daily_claim(user_id)
+        if last_claim == today:
+            return False
+        await self.point_service.add_points(user_id, 10, reason="daily_reward")
+        await database.update_daily_claim(user_id, today)
+        return True

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -39,6 +39,24 @@ class MissionService:
             )
             await db.commit()
 
+    async def get_active_mission(self) -> Dict | None:
+        now = datetime.utcnow().isoformat()
+        async with aiosqlite.connect(DB_PATH) as db:
+            cursor = await db.execute(
+                """
+                SELECT * FROM missions
+                WHERE (active_from IS NULL OR active_from<=?)
+                AND (active_until IS NULL OR active_until>=?)
+                ORDER BY mission_id LIMIT 1
+                """,
+                (now, now),
+            )
+            row = await cursor.fetchone()
+            if row:
+                columns = [c[0] for c in cursor.description]
+                return dict(zip(columns, row))
+            return None
+
     async def check_user_mission_completion(self, user_id: int, mission_id: int, current_data: Dict) -> bool:
         async with aiosqlite.connect(DB_PATH) as db:
             cursor = await db.execute(

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -2,7 +2,11 @@ from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 
 def start_keyboard(is_admin: bool = False) -> InlineKeyboardMarkup:
-    buttons = [[InlineKeyboardButton(text="Perfil", callback_data="profile")]]
+    buttons = [
+        [InlineKeyboardButton(text="Mi perfil", callback_data="profile")],
+        [InlineKeyboardButton(text="Recompensa diaria", callback_data="daily_reward")],
+        [InlineKeyboardButton(text="Tarea semanal", callback_data="weekly_task")],
+    ]
     if is_admin:
         buttons.append([InlineKeyboardButton(text="Panel admin", callback_data="admin")])
     return InlineKeyboardMarkup(inline_keyboard=buttons)


### PR DESCRIPTION
## Summary
- expand inline menu with three options
- implement callbacks for profile, daily reward, and weekly task
- add DailyRewardService and daily reward DB table
- expose active mission query

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dc75120208329a449ec8dc424dae3