### PR TITLE
Implement VIP auctions and daily gifts

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -160,6 +160,62 @@ async def init_db() -> None:
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS auctions (
+                auction_id INTEGER PRIMARY KEY,
+                item_name TEXT,
+                description TEXT,
+                start_time TEXT,
+                end_time TEXT,
+                winner_user_id INTEGER,
+                winning_bid INTEGER,
+                status TEXT DEFAULT 'active'
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bids (
+                bid_id INTEGER PRIMARY KEY,
+                auction_id INTEGER,
+                user_id INTEGER,
+                bid_amount INTEGER,
+                bid_time TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS daily_gifts (
+                gift_id INTEGER PRIMARY KEY,
+                description TEXT,
+                points_reward INTEGER,
+                gift_type TEXT,
+                content TEXT,
+                active_date TEXT UNIQUE
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS claimed_daily_gifts (
+                user_id INTEGER,
+                gift_id INTEGER,
+                claimed_date TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS weekly_ranking_activity (
+                user_id INTEGER,
+                week_number INTEGER,
+                total_activity_points INTEGER,
+                total_purchase_amount REAL
+            )
+            """
+        )
         await db.commit()
 
 async def create_user(user_id: int, username: str | None, full_name: str) -> None:

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,10 +1,12 @@
 from aiogram import Router
 
+from aiogram import Router
 from .start_menu import router as start_menu_router
 from .profile_commands import router as profile_router
 from .interaction_handlers import router as interaction_router
 from .admin_commands import router as admin_router
 from .user_commands import router as user_cmd_router
+from .echo_handler import router as echo_router
 
 
 def register_handlers() -> Router:
@@ -14,4 +16,5 @@ def register_handlers() -> Router:
     router.include_router(interaction_router)
     router.include_router(admin_router)
     router.include_router(user_cmd_router)
+    router.include_router(echo_router)
     return router

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -1,15 +1,18 @@
 from aiogram import Router, types
 from aiogram.filters import Command
+from datetime import datetime
 
 from config import ADMIN_IDS
 from services.purchase_service import PurchaseService
 from services.point_service import PointService
 from services.mission_service import MissionService
+from services.auction_service import AuctionService
 
 router = Router()
 purchase_service = PurchaseService()
 point_service = PointService()
 mission_service = MissionService()
+auction_service = AuctionService()
 
 
 @router.message(Command("sumarpuntos"))
@@ -56,3 +59,16 @@ async def cmd_activar_mision(message: types.Message):
     mission_id = int(parts[1])
     await mission_service.activate_mission(mission_id)
     await message.answer("Mision activada")
+
+
+@router.message(Command("crearsubasta"))
+async def cmd_crearsubasta(message: types.Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    parts = message.text.split(maxsplit=3)
+    if len(parts) < 4:
+        await message.answer("Uso: /crearsubasta [nombre] [descripcion] [fecha_fin]")
+        return
+    _, name, desc, end_time = parts
+    auction_id = await auction_service.create_auction(name, desc, datetime.utcnow().isoformat(), end_time)
+    await message.answer(f"Subasta creada ID {auction_id}")

--- a/handlers/echo_handler.py
+++ b/handlers/echo_handler.py
@@ -1,0 +1,9 @@
+from aiogram import Router, types
+
+router = Router()
+
+
+@router.message()
+async def echo(message: types.Message):
+    if message.text:
+        await message.answer(message.text)

--- a/handlers/user_commands.py
+++ b/handlers/user_commands.py
@@ -1,10 +1,16 @@
 from aiogram import Router, types
 from aiogram.filters import Command
+import aiosqlite
+from db.database import DB_PATH
 
 from services.reward_service import RewardService
+from services.auction_service import AuctionService
+from services.daily_gift_service import DailyGiftService
 
 router = Router()
 reward_service = RewardService()
+auction_service = AuctionService()
+daily_gift_service = DailyGiftService()
 
 
 @router.message(Command("catalogo"))
@@ -30,3 +36,44 @@ async def cmd_canjear(message: types.Message, bot):
         return
     await reward_service.deliver_reward(message.from_user.id, reward_id, bot)
     await message.answer("Recompensa canjeada")
+
+
+@router.message(Command("pujar"))
+async def cmd_pujar(message: types.Message):
+    parts = message.text.split()
+    if len(parts) < 2:
+        await message.answer("Uso: /pujar [cantidad_puntos]")
+        return
+    bid = int(parts[1])
+    async with aiosqlite.connect(str(DB_PATH)) as db:
+        cur = await db.execute(
+            "SELECT auction_id FROM auctions WHERE status='active' ORDER BY start_time LIMIT 1"
+        )
+        row = await cur.fetchone()
+        if not row:
+            await message.answer("No hay subastas activas")
+            return
+        auction_id = row[0]
+    success = await auction_service.place_bid(auction_id, message.from_user.id, bid)
+    if success:
+        await message.answer("Puja registrada")
+    else:
+        await message.answer("Puja no v\u00e1lida")
+
+
+@router.message(Command("regalodiario"))
+async def cmd_regalodiario(message: types.Message, bot):
+    gift = await daily_gift_service.get_current_daily_gift()
+    if not gift:
+        await message.answer("No hay regalo hoy")
+        return
+    if await daily_gift_service.has_claimed_today(message.from_user.id):
+        await message.answer("Ya reclamaste el regalo de hoy")
+        return
+    info = await daily_gift_service.claim_gift(message.from_user.id, gift["gift_id"])
+    if not info:
+        await message.answer("Error al reclamar")
+        return
+    if info["gift_type"] == "text" and info["content"]:
+        await bot.send_message(message.from_user.id, info["content"])
+    await message.answer("Regalo obtenido")

--- a/main.py
+++ b/main.py
@@ -13,6 +13,10 @@ from cron_jobs import (
     daily_reset_interaction_limit,
     award_permanence_points_job,
     check_and_award_missions,
+    finalize_auctions_job,
+    run_monthly_raffle,
+    run_weekly_mini_raffle,
+    update_weekly_activity_ranking,
 )
 
 
@@ -44,6 +48,10 @@ async def on_startup(bot: Bot) -> None:
     scheduler.add_daily_job(daily_reset_interaction_limit)
     scheduler.add_daily_job(award_permanence_points_job)
     scheduler.add_daily_job(check_and_award_missions)
+    scheduler.add_daily_job(finalize_auctions_job)
+    scheduler.add_daily_job(run_monthly_raffle)
+    scheduler.add_daily_job(run_weekly_mini_raffle)
+    scheduler.add_daily_job(update_weekly_activity_ranking)
     dp.loop.create_task(scheduler.start(bot))
     logging.info("Bot started")
 

--- a/services/auction_service.py
+++ b/services/auction_service.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from typing import Optional
+
+import aiosqlite
+from aiogram import Bot
+
+from db.database import DB_PATH
+from .point_service import PointService
+from .badge_service import BadgeService
+
+
+class AuctionService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+        self.badge_service = BadgeService()
+
+    async def create_auction(self, item_name: str, description: str, start_time: str, end_time: str) -> int:
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                """
+                INSERT INTO auctions(item_name, description, start_time, end_time)
+                VALUES (?,?,?,?)
+                """,
+                (item_name, description, start_time, end_time),
+            )
+            await db.commit()
+            return cursor.lastrowid
+
+    async def place_bid(self, auction_id: int, user_id: int, bid_amount: int) -> bool:
+        now = datetime.utcnow().isoformat()
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                "SELECT end_time, status FROM auctions WHERE auction_id=?",
+                (auction_id,),
+            )
+            row = await cursor.fetchone()
+            if not row or row[1] != "active" or row[0] <= now:
+                return False
+            cur = await db.execute(
+                "SELECT MAX(bid_amount) FROM bids WHERE auction_id=?",
+                (auction_id,),
+            )
+            max_row = await cur.fetchone()
+            max_bid = max_row[0] if max_row and max_row[0] else 0
+            if bid_amount <= max_bid:
+                return False
+            await db.execute(
+                "INSERT INTO bids(auction_id, user_id, bid_amount, bid_time) VALUES (?,?,?,?)",
+                (auction_id, user_id, bid_amount, now),
+            )
+            await db.commit()
+            return True
+
+    async def finalize_auction(self, auction_id: int, bot: Bot) -> None:
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                "SELECT end_time, status FROM auctions WHERE auction_id=?",
+                (auction_id,),
+            )
+            row = await cursor.fetchone()
+            if not row or row[1] != "active" or row[0] > datetime.utcnow().isoformat():
+                return
+            bcur = await db.execute(
+                "SELECT user_id, bid_amount FROM bids WHERE auction_id=? ORDER BY bid_amount DESC LIMIT 1",
+                (auction_id,),
+            )
+            bid_row = await bcur.fetchone()
+            if not bid_row:
+                await db.execute(
+                    "UPDATE auctions SET status='finished' WHERE auction_id=?",
+                    (auction_id,),
+                )
+                await db.commit()
+                return
+            winner, winning_bid = bid_row
+        success = await self.point_service.deduct_points(winner, winning_bid)
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            await db.execute(
+                "UPDATE auctions SET winner_user_id=?, winning_bid=?, status='finished' WHERE auction_id=?",
+                (winner, winning_bid, auction_id),
+            )
+            await db.commit()
+        if success:
+            await bot.send_message(winner, f"Felicidades! Ganaste la subasta con {winning_bid} puntos")
+            await self.award_collector_badge(winner)
+
+    async def award_collector_badge(self, user_id: int) -> None:
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                "SELECT badge_id FROM badges WHERE name=?",
+                ("Coleccionista Exclusivo",),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return
+            badge_id = row[0]
+        await self.badge_service.award_badge(user_id, badge_id)

--- a/services/daily_gift_service.py
+++ b/services/daily_gift_service.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from typing import Dict, Optional
+
+import aiosqlite
+
+from db.database import DB_PATH
+from .point_service import PointService
+
+
+class DailyGiftService:
+    def __init__(self) -> None:
+        self.point_service = PointService()
+
+    async def get_current_daily_gift(self) -> Optional[Dict]:
+        today = datetime.utcnow().date().isoformat()
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                "SELECT * FROM daily_gifts WHERE active_date=?",
+                (today,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            columns = [c[0] for c in cursor.description]
+            return dict(zip(columns, row))
+
+    async def has_claimed_today(self, user_id: int) -> bool:
+        today = datetime.utcnow().date().isoformat()
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM claimed_daily_gifts WHERE user_id=? AND claimed_date=?",
+                (user_id, today),
+            )
+            return bool(await cursor.fetchone())
+
+    async def claim_gift(self, user_id: int, gift_id: int) -> Optional[Dict]:
+        if await self.has_claimed_today(user_id):
+            return None
+        async with aiosqlite.connect(str(DB_PATH)) as db:
+            cursor = await db.execute(
+                "SELECT description, points_reward, gift_type, content FROM daily_gifts WHERE gift_id=?",
+                (gift_id,),
+            )
+            gift_row = await cursor.fetchone()
+            if not gift_row:
+                return None
+            description, points_reward, gtype, content = gift_row
+            await db.execute(
+                "INSERT INTO claimed_daily_gifts(user_id, gift_id, claimed_date) VALUES (?,?,?)",
+                (user_id, gift_id, datetime.utcnow().date().isoformat()),
+            )
+            await db.commit()
+        if points_reward:
+            await self.point_service.add_points(user_id, points_reward, reason="daily_gift")
+        return {
+            "description": description,
+            "points_reward": points_reward,
+            "gift_type": gtype,
+            "content": content,
+        }


### PR DESCRIPTION
## Summary
- create tables for auctions, daily gifts, bids and rankings
- add `AuctionService` and `DailyGiftService`
- implement admin command to create auctions
- implement user commands to bid and claim daily gifts
- add echo handler and register it
- extend cron jobs for auctions and raffles
- register new cron jobs in `main`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd327ba048329b39c497c24a9b915